### PR TITLE
Add GET (show) endpoint for a single record in HelpRequest table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -76,7 +76,7 @@ public class HelpRequestsController extends ApiController {
         return savedHelpRequest;
     }
 
-    @Operation(summary= "Get a single help request")
+    @Operation(summary= "Get a single help request by id")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
     public HelpRequests getById(

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -148,7 +148,7 @@ public class HelpRequestsControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
-        // Tests for GET /api/ucsbdates?id=...
+        // Tests for GET /api/helprequests?id=...
 
         @Test
         public void logged_out_users_cannot_get_by_id() throws Exception {


### PR DESCRIPTION
Close #34 and adds get by id for Help Requests. Can post a helprequest and then use /api/helprequests?id= at https://team02-madhav-ucsb-dev.dokku-09.cs.ucsb.edu. 