### PR TITLE
Added delete api endpoint for helprequests table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -99,7 +99,7 @@ public class HelpRequestsController extends ApiController {
         return genericMessage("HelpRequest with id %s deleted".formatted(id));
     }
 
-    @Operation(summary= "Update a single help request")
+    @Operation(summary= "Update a help request")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("")
     public HelpRequests updateHelpRequests(

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -268,7 +268,7 @@ public class HelpRequestsControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+        public void admin_can_edit_an_existing_helprequest() throws Exception {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -316,7 +316,7 @@ public class HelpRequestsControllerTests extends ControllerTestCase {
         
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
-        public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+        public void admin_cannot_edit_helprequest_that_does_not_exist() throws Exception {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");


### PR DESCRIPTION
Added delete endpoint where you can you delete and endpoint by specified id. It will throw an error if the id of the helprequest does not exist in the database. Closes #36 https://team02-madhav-ucsb-dev.dokku-09.cs.ucsb.edu/